### PR TITLE
fixed cancel button not being disable after sorting 

### DIFF
--- a/src/main/java/io/github/compilerstuck/Control/MainController.java
+++ b/src/main/java/io/github/compilerstuck/Control/MainController.java
@@ -140,6 +140,7 @@ public class MainController extends PApplet {
 
                 settings.setProgressBar(100);
                 settings.setEnableInputs(true);
+                settings.setEnableCancelButton(false);
             } else if (running) {
                 visualization.update();
                 arrayController.update();

--- a/src/main/java/io/github/compilerstuck/Control/Settings.java
+++ b/src/main/java/io/github/compilerstuck/Control/Settings.java
@@ -405,6 +405,10 @@ public class Settings extends JFrame {
         visualizationListComboBox.setEnabled(enabled);
     }
 
+    public void setEnableCancelButton(boolean enabled){
+        cancelButton.setEnabled(enabled);
+    }
+
     public void setProgressBar(int progress) {
         progressBarArray.setValue(progress);
     }


### PR DESCRIPTION
Related to #2 

- created a new method in Settings, allowing to disable/enable the cancel button
- made sure the cancel button gets disable when the visuals are being resetted for a new run 