### PR TITLE
Fix: Make Settings window resizable on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 
   <p align="center">
     Visualizes and Audiolizes Sorting Algorithms!<br/>
-    (Not actively maintained)
     <br />
     <br />
     <a href="https://github.com/66-m/sorting-visualizer/releases/latest"><strong>Try it »</strong></a>

--- a/src/main/java/io/github/compilerstuck/Control/Settings.java
+++ b/src/main/java/io/github/compilerstuck/Control/Settings.java
@@ -75,10 +75,11 @@ public class Settings extends JFrame {
 
         //Frame Settings
         setContentPane(settingsPanel);
-        setSize(600, 530);
+        setSize(650, 600);
         setLocation(10, 10);
         setDefaultCloseOperation(EXIT_ON_CLOSE);
-        setResizable(false);
+        setResizable(true);
+        setMinimumSize(new Dimension(650, 600));
         setTitle("Sorting Algorithm Visualizer - Settings");
         //setIconImage(new ImageIcon("src/main/resources/ChannelLogoWhite_64x64.png").getImage());
 


### PR DESCRIPTION
- Enable window resizing (setResizable(true))
- Increase default size to 650x600 for better display
- Add minimum size constraint

Fixes #22